### PR TITLE
Parsing speed optimization for large files

### DIFF
--- a/__tests__/getEntriesBoundaries.test.js
+++ b/__tests__/getEntriesBoundaries.test.js
@@ -2,11 +2,11 @@
 
 let fs = require('fs');
 
-let split = require('../src/split');
+let getEntriesBoundaries = require('../src/getEntriesBoundaries');
 
 let sdf0 = fs.readFileSync(`${__dirname}/test.sdf`, 'utf-8');
-let sdf1 = fs.readFileSync(`${__dirname}/test.sdf`, 'utf-8');
-let sdf2 = fs.readFileSync(`${__dirname}/test.sdf`, 'utf-8');
+let sdf1 = fs.readFileSync(`${__dirname}/test1.sdf`, 'utf-8');
+let sdf2 = fs.readFileSync(`${__dirname}/test2.sdf`, 'utf-8');
 
 [sdf0, sdf1, sdf2].forEach(sdf => {
     let eol = '\n';
@@ -19,6 +19,6 @@ let sdf2 = fs.readFileSync(`${__dirname}/test.sdf`, 'utf-8');
 
     test('Split should match regex behavior', function () {
         let sdfParts = sdf.split(new RegExp(`${eol}\\$\\$\\$\\$.*${eol}`));
-        expect(sdfParts).toEqual(split(sdf, `${eol}$$$$`, eol).map(v => sdf.substring(...v)));
+        expect(sdfParts).toEqual(getEntriesBoundaries(sdf, `${eol}$$$$`, eol).map(v => sdf.substring(...v)));
     });
 })

--- a/src/getEntriesBoundaries.js
+++ b/src/getEntriesBoundaries.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function indicesOfSplit(string, substring, eol) {
+function getEntriesBoundaries(string, substring, eol) {
     const res = [];
     let previous = 0;
     let next = 0;
@@ -16,4 +16,4 @@ function indicesOfSplit(string, substring, eol) {
     return res;
 }
 
-module.exports = indicesOfSplit;
+module.exports = getEntriesBoundaries;

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const split = require("./split");
+const getEntriesBoundaries = require("./getEntriesBoundaries");
 
 function parse(sdf, options = {}) {
   const {
@@ -30,14 +30,14 @@ function parse(sdf, options = {}) {
     }
   }
 
-  let sdfParts = split(sdf, `${eol}$$$$`, eol);
+  let entriesBoundaries = getEntriesBoundaries(sdf, `${eol}$$$$`, eol);
   let molecules = [];
   let labels = {};
 
   let start = Date.now();
 
-  for (let i = 0; i < sdfParts.length; i++) {
-    let sdfPart = sdf.substring(...sdfParts[i]);
+  for (let i = 0; i < entriesBoundaries.length; i++) {
+    let sdfPart = sdf.substring(...entriesBoundaries[i]);
     let parts = sdfPart.split(`${eol}>`);
     if (parts.length > 0 && parts[0].length > 5) {
       let molecule = {};


### PR DESCRIPTION
This PR replaces regex with solution based around indexOf. 
On our datasets it cuts down time to parse a file from 13 seconds to 1.

PR comes with tests to verify it matches old behavior. 